### PR TITLE
2 namespace clash with concat

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,12 +10,14 @@ class phpmyadmin::params
       $apache_default_config = '/etc/httpd/conf.d/phpMyAdmin.conf'
       $config_file           = '/etc/phpMyAdmin/config.inc.php'
       $doc_path              = '/usr/share/phpMyAdmin'
+      $data_dir              = '/var/lib/phpMyAdmin'
     }
     /^(Debian|Ubuntu)$/: {
       $package_name = 'phpmyadmin'
       $apache_default_config = '/etc/phpmyadmin/apache.conf'
       $config_file           = '/etc/phpmyadmin/config.inc.php'
-      $doc_path              = '/usr/share/phpMyAdmin'
+      $doc_path              = '/usr/share/phpmyadmin'
+      $data_dir              = '/var/lib/phpmyadmin'
     }
   }
 

--- a/templates/config_footer.inc.php.erb
+++ b/templates/config_footer.inc.php.erb
@@ -17,8 +17,8 @@
 /*
  * Directories for saving/loading files from server
  */
-$cfg['UploadDir'] = '/var/lib/phpMyAdmin/upload';
-$cfg['SaveDir'] = '/var/lib/phpMyAdmin/save';
+$cfg['UploadDir'] = '<%= scope.lookupvar('phpmyadmin::params::data_dir') %>/upload';
+$cfg['SaveDir'] = '<%= scope.lookupvar('phpmyadmin::params::data_dir') %>/save';
 
 /**
  * Defines whether a user should be displayed a "show all (records)"

--- a/templates/phpMyAdmin.conf.erb
+++ b/templates/phpMyAdmin.conf.erb
@@ -7,10 +7,10 @@
 # But allowing phpMyAdmin to anyone other than localhost should be considered
 # dangerous unless properly secured by SSL
 
-Alias /phpMyAdmin /usr/share/phpMyAdmin
-Alias /phpmyadmin /usr/share/phpMyAdmin
+Alias /phpMyAdmin <%= doc_path %>
+Alias /phpmyadmin <%= doc_path %>
 
-<Directory /usr/share/phpMyAdmin/>
+<Directory <%= doc_path %>/>
    <IfModule mod_authz_core.c>
      # Apache 2.4
      Require local
@@ -26,7 +26,7 @@ Alias /phpmyadmin /usr/share/phpMyAdmin
    </IfModule>
 </Directory>
 
-<Directory /usr/share/phpMyAdmin/setup/>
+<Directory <%= doc_path %>/setup/>
    <IfModule mod_authz_core.c>
      # Apache 2.4
      Require local
@@ -45,19 +45,19 @@ Alias /phpmyadmin /usr/share/phpMyAdmin
 # These directories do not require access over HTTP - taken from the original
 # phpMyAdmin upstream tarball
 #
-<Directory /usr/share/phpMyAdmin/libraries/>
+<Directory <%= doc_path %>/libraries/>
     Order Deny,Allow
     Deny from All
     Allow from None
 </Directory>
 
-<Directory /usr/share/phpMyAdmin/setup/lib/>
+<Directory <%= doc_path %>/setup/lib/>
     Order Deny,Allow
     Deny from All
     Allow from None
 </Directory>
 
-<Directory /usr/share/phpMyAdmin/setup/frames/>
+<Directory <%= doc_path %>/setup/frames/>
     Order Deny,Allow
     Deny from All
     Allow from None
@@ -67,7 +67,7 @@ Alias /phpmyadmin /usr/share/phpMyAdmin
 # filtering SQL etc.  This may break your mod_security implementation.
 #
 #<IfModule mod_security.c>
-#    <Directory /usr/share/phpMyAdmin/>
+#    <Directory <%= doc_path %>/>
 #        SecRuleInheritance Off
 #    </Directory>
 #</IfModule>


### PR DESCRIPTION
This addresses some of the issues I found while testing, including using the values from phpmyadmin::params in some of the templates.

More importantly, and as not described in the issue subject, this adds support for Debian based systems. 
