### PR TITLE
Incorect syntax in phpmyadmin vhost class definition

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -60,7 +60,7 @@ inherits phpmyadmin::params
         'true'  => 'present',
         default => 'absent',
       },
-      ssl           => $ssl
+      ssl           => $ssl,
       port          => $ssl ? { #Might need to add ability to define port. Consider...
         'true'  => '443',
         default => '80',


### PR DESCRIPTION
I am still testing the changes.  Thanks for all the work earlier this week!
