### PR TITLE
Debian Apache Config Correction

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,7 @@ inherits phpmyadmin::params
     },
     content => template('phpmyadmin/phpMyAdmin.conf.erb'),
     require => Package[$phpmyadmin::params::package_name],
+    notify  => Service[$phpmyadmin::params::apache_name],
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,7 @@ class phpmyadmin::params
       $config_file           = '/etc/phpMyAdmin/config.inc.php'
       $doc_path              = '/usr/share/phpMyAdmin'
       $data_dir              = '/var/lib/phpMyAdmin'
+      $apache_name           = 'httpd'
       $preseed_package       = false
     }
     /^(Debian|Ubuntu)$/: {
@@ -23,6 +24,7 @@ class phpmyadmin::params
       $config_file           = '/etc/phpmyadmin/config.inc.php'
       $doc_path              = '/usr/share/phpmyadmin'
       $data_dir              = '/var/lib/phpmyadmin'
+      $apache_name           = 'apache2'
       $preseed_package       = true
     }
     default: { }


### PR DESCRIPTION
Currently, this module sets up Debian and Ubuntu operating systems to use the config file served from /etc/phpmyadmin/apache.conf, but does not manage the symlink to that file.  On first run, the phpmyadmin package will setup this symlink.  However, once puppet runs again, this unmanaged symlink will be deleted.  The easiest way to compensate for this is by simply hosting the $apache_default_config file on Debian family operating systems out of the Apache2 config directory.

This file change should also notify the Apache service.

Alternatively, this fix can be accomplished via managing the symlink on Debian family systems.  [I went this route initially](https://github.com/atomaka/puppet-phpmyadmin/tree/bugfix-symlink), but simply moving the file is much cleaner and makes notifying Apache simpler.

Tested on Ubuntu 12.04.
