### PR TITLE
Add extra settings for servernode

### DIFF
--- a/manifests/servernode.pp
+++ b/manifests/servernode.pp
@@ -8,6 +8,10 @@
 #   It default to the defined resource name
 # [*server_group*]
 #   If used as a defined resource, this will be used to select which servers to install for a specific phpmyadmin instance.
+# [*verbose_name*]
+#   The name which will appear in the list of servers (default: $name)
+# [*hide_db*]
+#   A regex describing the database names to hide (default: '')
 #
 # === Examples
 #
@@ -32,6 +36,8 @@
 define phpmyadmin::servernode (
   $server_group,
   $myserver_name = $name,
+  $verbose_name  = $name,
+  $hide_db       = '',
   $target        = $::phpmyadmin::params::config_file,
 ) {
   include ::phpmyadmin::params

--- a/templates/servernode.erb
+++ b/templates/servernode.erb
@@ -2,10 +2,12 @@ $i++;
 /* Authentication type */
 $cfg['Servers'][$i]['auth_type'] = 'cookie';
 /* Server parameters */
-$cfg['Servers'][$i]['host'] = '<%= myserver_name %>';
+$cfg['Servers'][$i]['host'] = '<%= @myserver_name %>';
+$cfg['Servers'][$i]['verbose_name'] = '<%= @verbose_name %>';
 $cfg['Servers'][$i]['connect_type'] = 'tcp';
 $cfg['Servers'][$i]['compress'] = false;
 /* Select mysql if your server does not have mysqli */
 $cfg['Servers'][$i]['extension'] = 'mysqli';
 $cfg['Servers'][$i]['AllowNoPassword'] = false;
+$cfg['Servers'][$i]['hide_db'] = '<%= @hide_db %>';
 /* ==================== */


### PR DESCRIPTION
Allow setting the verbose_name and hide_db settings for servers in the phpmyadmin config.inc.php file.
