### PR TITLE
Fix: Verbose name parameter. Setting Apache config even when not mana…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,14 @@ class phpmyadmin (
       mpm_module => 'prefork',
     }
     include ::apache::mod::php
+
+    #Default/basic apache config file for phpMyAdmin
+    file { $apache_default_config:
+      ensure  => $state_select,
+      content => template('phpmyadmin/phpMyAdmin.conf.erb'),
+      require => Package[$package_name],
+      notify  => Service[$apache_name],
+    }
   }
 
   $enabledt = str2bool($enabled)
@@ -75,14 +83,4 @@ class phpmyadmin (
 
   #Install or remove package based on enable status
   ensure_packages([$package_name], { ensure => $state_select })
-
-  #Default/basic apache config file for phpMyAdmin
-  file { $apache_default_config:
-    ensure  => $state_select,
-    content => template('phpmyadmin/phpMyAdmin.conf.erb'),
-    require => Package[$package_name],
-    notify  => Service[$apache_name],
-  }
-
 }
-

--- a/templates/servernode.erb
+++ b/templates/servernode.erb
@@ -3,7 +3,7 @@ $i++;
 $cfg['Servers'][$i]['auth_type'] = 'cookie';
 /* Server parameters */
 $cfg['Servers'][$i]['host'] = '<%= @myserver_name %>';
-$cfg['Servers'][$i]['verbose_name'] = '<%= @verbose_name %>';
+$cfg['Servers'][$i]['verbose'] = '<%= @verbose_name %>';
 $cfg['Servers'][$i]['connect_type'] = 'tcp';
 $cfg['Servers'][$i]['compress'] = false;
 /* Select mysql if your server does not have mysqli */


### PR DESCRIPTION
Hi,

According to the [PHPMyAdmin docs](https://wiki.phpmyadmin.net/pma/Config/Servers#verbose) ```verbose_name``` needs to be just ```verbose```.

Also  ```$apache_default_config``` should only be managed when ```$manage_apache``` is set to true. This caused Apache to break on my setup.

Cheers,