### PR TITLE
Separate out blowfish secret into another file

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -51,6 +51,13 @@ define phpmyadmin::server (
     group   => '0',
     mode    => '0644',
     require => Package[$package_name],
+  } ->
+  file { '/var/lib/phpmyadmin/blowfish_secret.inc.php':
+    ensure  => 'present',
+    owner   => 'root',
+    group   => 'www-data',
+    mode    => '0640',
+    content => template('phpmyadmin/blowfish_secret.inc.php.erb'),
   }
 
   #Default header

--- a/templates/blowfish_secret.inc.php.erb
+++ b/templates/blowfish_secret.inc.php.erb
@@ -1,0 +1,2 @@
+<?php
+$cfg['blowfish_secret'] = '<%= @blowfish_key %>';

--- a/templates/config_header.inc.php.erb
+++ b/templates/config_header.inc.php.erb
@@ -16,7 +16,10 @@
  * This is needed for cookie based authentication to encrypt password in
  * cookie
  */
-$cfg['blowfish_secret'] = '<%= @blowfish_key %>'; /* YOU MUST FILL IN THIS FOR COOKIE AUTH! */
+include('/var/lib/phpmyadmin/blowfish_secret.inc.php');
+if (file_exists('/var/lib/phpmyadmin/config.inc.php')) {
+  include('/var/lib/phpmyadmin/config.inc.php');
+}
 
 $cfg['PropertiesIconic'] = <%= @properties_iconic %>;
 


### PR DESCRIPTION
This means that regular users can't discover the secret and is in line
with the Debian distribution config