### PR TITLE
Force replacing config file content with valid config template file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,7 @@ class phpmyadmin (
     file { $apache_default_config:
       ensure  => $state_select,
       content => template('phpmyadmin/phpMyAdmin.conf.erb'),
+      force   => true,
       require => Package[$package_name],
       notify  => Service[$apache_name],
     }


### PR DESCRIPTION
If you use the real Debian conf-enabled folder (instead of conf.d on other Linux flavor), you can end up with that warning: Warning: /Stage[main]/Phpmyadmin/File[/etc/apache2/conf-enabled/phpmyadmin.conf]: Ensure set to :present but file type is link so no content will be synced because the phpmyadmin.conf link is created by the phpmyadmin package. 

To avoid that warning and use the right config template file, you must force the file resource to use the content provided.